### PR TITLE
ci: refresh actions for Node 24 runtime

### DIFF
--- a/.github/workflows/test-snap-can-build.yml
+++ b/.github/workflows/test-snap-can-build.yml
@@ -1,5 +1,8 @@
 name: Build and smoke test snap
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 on:
   push:
     branches: [ main ]
@@ -14,10 +17,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Build snap
-        uses: snapcore/action-build@v1
+        uses: canonical/action-build@v1.3.0
         id: build
 
       - name: Show log on build failure
@@ -25,13 +28,13 @@ jobs:
         run: cat /home/runner/.local/state/snapcraft/log/snapcraft*.log
 
       - name: Review snap
-        uses: diddlesnaps/snapcraft-review-action@v1
+        uses: diddlesnaps/snapcraft-review-action@v1.3.1
         with:
           snap: ${{ steps.build.outputs.snap }}
           isClassic: 'false'
 
       - name: Upload snap artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: snap
           path: ${{ steps.build.outputs.snap }}
@@ -47,10 +50,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Download snap artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: snap
 
@@ -94,7 +97,7 @@ jobs:
         run: ghvmctl exec -- cat /home/ubuntu/mindustry.mindustry.log 2>/dev/null || true
 
       - name: Upload screenshots
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         if: always()
         with:
           name: smoke-test-screenshots
@@ -105,7 +108,7 @@ jobs:
       - name: Comment on PR with screenshot link
         if: github.event_name == 'pull_request'
         continue-on-error: true
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |


### PR DESCRIPTION
## Summary
- update official GitHub actions to current Node 24-capable majors
- move snap building to `canonical/action-build@v1.3.0` and update snap review to `diddlesnaps/snapcraft-review-action@v1.3.1`
- opt the workflow into Node 24 now with `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true`

## Context
The v157.4 validation run passed, but GitHub emitted Node.js 20 deprecation warnings for the workflow actions. This PR exercises the Node 24 runtime ahead of GitHub forcing it by default on 2026-06-02 and removing Node 20 from runners on 2026-09-16.

## Validation
- `git diff --check`
- parsed `.github/workflows/test-snap-can-build.yml` with Python/PyYAML
- confirmed updated action refs exist via GitHub API
